### PR TITLE
fix(clr): Order shared AQL ring publication on Intel hosts (AIRUNTIME-2291)

### DIFF
--- a/rocclr/device/rocm/rocdevice.cpp
+++ b/rocclr/device/rocm/rocdevice.cpp
@@ -3198,7 +3198,7 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
     if (cuMask.size() != 0) {
       // add queues with custom CU mask into their special pool to keep track
       // of mapping of these queues to their associated queueInfo (i.e., hostcall buffers)
-      auto result = queueWithCUMaskPool_[qIndex].emplace(std::make_pair(queue, QueueInfo()));
+      auto result = queueWithCUMaskPool_[qIndex].try_emplace(queue);
       assert(result.second && "QueueInfo already exists");
       auto& qInfo = result.first->second;
       qInfo.refCount = 1;
@@ -3212,13 +3212,30 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
     // per device.
     return queue;
   }
-  auto result = queuePool_[qIndex].emplace(std::make_pair(queue, QueueInfo()));
+  auto result = queuePool_[qIndex].try_emplace(queue);
   assert(result.second && "QueueInfo already exists");
   auto &qInfo = result.first->second;
   qInfo.refCount = 1;
   ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "acquireQueue refCount: %p (%d)",
           result.first->first->base_address, result.first->second.refCount);
   return queue;
+}
+
+AqlOrderedPublishState* Device::GetAqlOrderedPublishState(hsa_queue_t* queue) {
+  if (!settings().isOrderedDoorbell_) {
+    return nullptr;
+  }
+  // Only the queues in this pool can be shared by several VirtualGPUs, so they are the only ones
+  // whose doorbells need ordering. CU masked queues live in their own pool and cooperative queues
+  // are never pooled, so both are absent here and ring as soon as their packet is written.
+  amd::ScopedLock lock(vgpusAccess());
+  for (auto& pool : queuePool_) {
+    auto qIter = pool.find(queue);
+    if (qIter != pool.end()) {
+      return &qIter->second.aqlPublishState_;
+    }
+  }
+  return nullptr;
 }
 
 void Device::releaseQueue(hsa_queue_t* queue, const std::vector<uint32_t>& cuMask) {

--- a/rocclr/device/rocm/rocdevice.hpp
+++ b/rocclr/device/rocm/rocdevice.hpp
@@ -76,6 +76,35 @@ class Resource;
 class VirtualDevice;
 class PrintfDbg;
 
+//! Doorbell order for one AQL ring shared by several streams.
+//!
+//! Slots are still reserved through the ring's own write index, so producers own disjoint slots
+//! and keep writing their packets in parallel. Only the doorbell is held back: a producer waits
+//! until the doorbell has been rung for every slot below its own, so the doorbell that sends CPF
+//! into the ring never fires while an earlier packet is still being written.
+//!
+//! Order is tracked in the ring's slot numbering, which is what the reservation already hands out,
+//! so there is no second counter to keep in step with it.
+struct alignas(64) AqlOrderedPublishState {
+  //! First slot whose doorbell has not been rung. A producer may ring once this reaches its own
+  //! first slot.
+  uint64_t DoorbellSlot() const { return doorbell_slot_.load(std::memory_order_acquire); }
+
+  //! Report every slot below |next_slot| written and rung. Never moves backwards: a write index
+  //! rewound from outside CLR must not leave a reservation waiting behind a slot that is gone.
+  void AdvanceDoorbell(uint64_t next_slot) {
+    uint64_t doorbell_slot = doorbell_slot_.load(std::memory_order_relaxed);
+    while (doorbell_slot < next_slot &&
+           !doorbell_slot_.compare_exchange_weak(doorbell_slot, next_slot,
+                                                 std::memory_order_release,
+                                                 std::memory_order_relaxed)) {
+    }
+  }
+
+ private:
+  alignas(64) std::atomic<uint64_t> doorbell_slot_{0};
+};
+
 class ProfilingSignal : public amd::ReferenceCountedObject {
 public:
   hsa_signal_t  signal_;  //!< HSA signal to track profiling information
@@ -565,6 +594,11 @@ class Device : public NullDevice {
   //! Release HSA queue
   void releaseQueue(hsa_queue_t*, const std::vector<uint32_t>& cuMask = {});
 
+  //! Doorbell order shared by every VirtualGPU using this physical queue. It is owned by the
+  //! queue pool, which outlives every VirtualGPU bound to the queue. Null when doorbell ordering
+  //! is disabled, which rings the doorbell as soon as the packet is written.
+  AqlOrderedPublishState* GetAqlOrderedPublishState(hsa_queue_t* queue);
+
   //! For the given HSA queue, return an existing hostcall buffer or create a
   //! new one. queuePool_ keeps a mapping from HSA queue to hostcall buffer.
   void* getOrCreateHostcallBuffer(hsa_queue_t* queue, bool coop_queue = false,
@@ -656,6 +690,8 @@ class Device : public NullDevice {
   struct QueueInfo {
     int refCount;
     void* hostcallBuffer_;
+    //! Doorbell order shared by every VirtualGPU using this physical queue.
+    AqlOrderedPublishState aqlPublishState_;
   };
 
   //! a vector for keeping Pool of HSA queues with low, normal and high priorities for recycling

--- a/rocclr/device/rocm/rocsettings.cpp
+++ b/rocclr/device/rocm/rocsettings.cpp
@@ -97,6 +97,15 @@ Settings::Settings() {
   kernel_arg_impl_ = KernelArgImpl::HostKernelArgs;
   gwsInitSupported_ = true;
   limit_blit_wg_ = 16;
+
+  // The multi-producer AQL ring race this ordering avoids has only been observed on Intel hosts,
+  // but nothing rules it out elsewhere, so the default orders every host. kOrderDoorbellIntelHosts
+  // narrows that to the hosts where it has been seen, and 0 turns the ordering off entirely.
+  constexpr uint kOrderDoorbellIntelHosts = 1;
+  constexpr uint kOrderDoorbellAllHosts = 2;
+  isOrderedDoorbell_ =
+      DEBUG_CLR_ORDER_DOORBELL >= kOrderDoorbellAllHosts ||
+      (DEBUG_CLR_ORDER_DOORBELL == kOrderDoorbellIntelHosts && amd::Os::isIntelCpu());
 }
 
 // ================================================================================================

--- a/rocclr/device/rocm/rocsettings.hpp
+++ b/rocclr/device/rocm/rocsettings.hpp
@@ -52,7 +52,8 @@ class Settings : public device::Settings {
       uint system_scope_signal_ : 1;    //!< HSA signal is visibile to the entire system
       uint fgs_kernel_arg_ : 1;         //!< Use fine grain kernel arg segment
       uint barrier_value_packet_ : 1;   //!< Barrier value packet functionality
-      uint reserved_ : 21;
+      uint isOrderedDoorbell_ : 1;      //!< Ring shared AQL ring doorbells in slot order
+      uint reserved_ : 20;
     };
     uint value_;
   };

--- a/rocclr/device/rocm/rocvirtual.cpp
+++ b/rocclr/device/rocm/rocvirtual.cpp
@@ -835,6 +835,67 @@ static inline void packet_store_release(uint32_t* packet, uint16_t header, uint1
 }
 
 // ================================================================================================
+// Streams outnumber hardware queues, so several VirtualGPUs end up multiplexed onto one physical
+// AQL ring, and hsa_queue_add_write_index_screlease() reserves a slot and advances the GPU-visible
+// write_dispatch_id in one step. The ring therefore advertises slots whose packets are still being
+// written, and CPF is sent to fetch one either by a doorbell from a producer holding a later slot
+// or by an HWS queue remap that re-reads write_dispatch_id:
+//
+//   RPTR = WPTR = 0
+//   T1 claims slot 0                           (write_dispatch_id -> 1)
+//   T2 claims slot 1                           (write_dispatch_id -> 2)
+//   T2 fills slot 1 and rings doorbell(1)
+//   CPF fetches slot 0, MEC sees an INVALID header and discards the ROQ    // defined behavior
+//   CPF re-fetches slot 0, but the 64B fetch is split into smaller reads somewhere on the way
+//   the read of the last 32B returns first, carrying junk from the previous trip through the ring
+//   T1 writes the body of slot 0, then releases its header
+//   the read of the first 32B returns, carrying the header T1 just wrote
+//   CPF assembles 64B that is half junk and half fresh, and the fresh half is a valid header, so
+//   MEC runs the packet with the junk body
+//
+// "INVALID header -> discard the ROQ" only covers the first look; on the re-fetch the header is
+// valid by the time it arrives, so nothing catches the torn packet. CPF asks for the packet as one
+// 64B unit and a fetch that stayed 64B would be a consistent snapshot; on Intel hosts it does not
+// appear to stay 64B, which is why this has only been seen there and why the ordering is gated on
+// the host vendor.
+//
+// What closes this is ordering the doorbell rather than the reservation: slots are still claimed
+// with one atomic add, so producers own disjoint slots and fill them in parallel, but a producer
+// holds its doorbell until every earlier slot has been written. T2 above then waits for T1, so no
+// doorbell sends CPF at a slot that is still being filled, and the doorbell values stay monotonic.
+//
+// Two ways in are left open, both of which predate this and are far rarer than the case above:
+// anything outside CLR ringing this ring's doorbell behind us - a profiler submitting to the same
+// ring - and an HWS queue remap re-reading write_dispatch_id while a reservation is still being
+// written. Holding the write index back until the packets were written would close both, but CLR
+// does not own that index: rocprofiler virtualizes it, and a store from here rewinds the shadow it
+// keeps, which is what hung counter collection.
+void VirtualGPU::CommitAqlSlots(uint64_t start_slot, uint64_t packet_count) {
+  assert(packet_count > 0);
+  const uint64_t commit_end = start_slot + packet_count;
+  if (aql_ordered_publish_state_ == nullptr) {
+    hsa_signal_store_screlease(gpu_queue_->doorbell_signal, commit_end - 1);
+    return;
+  }
+
+  // Wait for every earlier slot's doorbell. A read index that reached this submission ends the
+  // wait too: those slots are already consumed, so nothing is left to tear, and a slot reserved
+  // here by anything other than CLR cannot stall the streams behind it.
+  //
+  // @note: an earlier producer holding a large reservation can keep this thread spinning for as
+  //        long as it takes to write all of its packets. If that ever costs a core, back off
+  //        exponentially instead of spinning.
+  while (aql_ordered_publish_state_->DoorbellSlot() < start_slot &&
+         hsa_queue_load_read_index_relaxed(gpu_queue_) < start_slot) {
+    amd::Os::spinPause();
+  }
+
+  hsa_signal_store_screlease(gpu_queue_->doorbell_signal, commit_end - 1);
+  // Let the next reservation ring: every slot below commit_end is written and rung.
+  aql_ordered_publish_state_->AdvanceDoorbell(commit_end);
+}
+
+// ================================================================================================
 template <typename AqlPacket>
 bool VirtualGPU::dispatchGenericAqlPacket(
   AqlPacket* packet, uint16_t header, uint16_t rest, bool blocking) {
@@ -929,7 +990,7 @@ bool VirtualGPU::dispatchGenericAqlPacket(
           reinterpret_cast<hsa_kernel_dispatch_packet_t*>(packet)->reserved2, read,
           index);
 
-  hsa_signal_store_screlease(gpu_queue_->doorbell_signal, index);
+  CommitAqlSlots(index, 1);
 
   // Mark the flag indicating if a dispatch is outstanding.
   // We are not waiting after every dispatch.
@@ -1075,7 +1136,7 @@ void VirtualGPU::dispatchBarrierPacket(uint16_t packetHeader, bool skipSignal,
   *aql_loc = barrier_packet_;
   __atomic_store_n(reinterpret_cast<uint32_t*>(aql_loc), packetHeader, __ATOMIC_RELEASE);
 
-  hsa_signal_store_screlease(gpu_queue_->doorbell_signal, index);
+  CommitAqlSlots(index, 1);
   ClPrint(amd::LOG_DEBUG, amd::LOG_AQL,
           "SWq=0x%zx, HWq=0x%zx, id=%d, BarrierAND Header = 0x%x (type=%d, barrier=%d, acquire=%d,"
           " release=%d), "
@@ -1153,7 +1214,7 @@ void VirtualGPU::dispatchBarrierValuePacket(uint16_t packetHeader, bool resolveD
   *aql_loc = barrier_value_packet_;
   packet_store_release(reinterpret_cast<uint32_t*>(aql_loc), packetHeader, rest);
 
-  hsa_signal_store_screlease(gpu_queue_->doorbell_signal, index);
+  CommitAqlSlots(index, 1);
 
   ClPrint(amd::LOG_DEBUG, amd::LOG_AQL,
           "SWq=0x%zx, HWq=0x%zx, id=%d, BarrierValue Header = 0x%x AmdFormat = 0x%x "
@@ -1211,6 +1272,7 @@ VirtualGPU::VirtualGPU(Device& device, bool profiling, bool cooperative,
     : device::VirtualDevice(device),
       state_(0),
       gpu_queue_(nullptr),
+      aql_ordered_publish_state_(nullptr),
       roc_device_(device),
       virtualQueue_(nullptr),
       deviceQueueSize_(0),
@@ -1329,6 +1391,10 @@ bool VirtualGPU::create() {
   uint32_t queue_size = ROC_AQL_QUEUE_SIZE;
   gpu_queue_ = roc_device_.acquireQueue(queue_size, cooperative_, cuMask_, priority_);
   if (!gpu_queue_) return false;
+
+  // Cache the doorbell order of the queue this vgpu is bound to. See CommitAqlSlots() for what it
+  // orders and why.
+  aql_ordered_publish_state_ = roc_device_.GetAqlOrderedPublishState(gpu_queue_);
 
   if (!initPool(dev().settings().kernargPoolSize_)) {
     LogError("Couldn't allocate arguments/signals for the queue");

--- a/rocclr/device/rocm/rocvirtual.hpp
+++ b/rocclr/device/rocm/rocvirtual.hpp
@@ -32,6 +32,7 @@
 #include "rocsched.hpp"
 
 namespace amd::roc {
+struct AqlOrderedPublishState;
 class Device;
 class Memory;
 struct ProfilingSignal;
@@ -427,6 +428,10 @@ class VirtualGPU : public device::VirtualDevice {
   //! Dispatches a barrier with blocking HSA signals
   void dispatchBlockingWait();
 
+  //! Ring the doorbell for a reservation, in reservation order. Every reserved slot must be
+  //! committed: an abandoned reservation stalls every stream sharing the HW queue.
+  void CommitAqlSlots(uint64_t start_slot, uint64_t packet_count);
+
   inline bool dispatchAqlPacket(uint8_t* aqlpacket, const std::string& kernelName,
                                 amd::AccumulateCommand* vcmd = nullptr);
   bool dispatchAqlPacket(hsa_kernel_dispatch_packet_t* packet, uint16_t header, uint16_t rest,
@@ -518,6 +523,10 @@ class VirtualGPU : public device::VirtualDevice {
   Timestamp* timestamp_;
   hsa_agent_t gpu_device_;  //!< Physical device
   hsa_queue_t* gpu_queue_;  //!< Queue associated with a gpu
+  //! Doorbell order shared by all VirtualGPUs on this pooled HW queue. Owned by the queue pool,
+  //! which outlives this object. Null when doorbell ordering is disabled, which rings the
+  //! doorbell as soon as the packet is written.
+  AqlOrderedPublishState* aql_ordered_publish_state_;
   hsa_barrier_and_packet_t barrier_packet_;
   hsa_amd_barrier_value_packet_t barrier_value_packet_;
 

--- a/rocclr/os/os.cpp
+++ b/rocclr/os/os.cpp
@@ -127,6 +127,24 @@ void Os::spinPause() {
 #endif
 }
 
+bool Os::isIntelCpu() {
+#if defined(ATI_ARCH_X86)
+  static const bool is_intel = [] {
+    // CPUID leaf 0 returns "GenuineIntel" in EBX, EDX, ECX.
+    constexpr int kGenuineIntelEbx = 0x756e6547;
+    constexpr int kGenuineIntelEdx = 0x49656e69;
+    constexpr int kGenuineIntelEcx = 0x6c65746e;
+    int registers[4] = {};
+    Os::cpuid(registers, 0);
+    return registers[1] == kGenuineIntelEbx && registers[3] == kGenuineIntelEdx &&
+           registers[2] == kGenuineIntelEcx;
+  }();
+  return is_intel;
+#else
+  return false;
+#endif  // ATI_ARCH_X86
+}
+
 void Os::sleep(long n) {
 // FIXME_lmoriche: Should be nano-seconds not seconds.
 #ifdef _WIN32

--- a/rocclr/os/os.hpp
+++ b/rocclr/os/os.hpp
@@ -162,6 +162,9 @@ class Os : AllStatic {
   //! Return the number of active processors in the system.
   inline static int processorCount();
 
+  //! Return true when the host CPU reports the GenuineIntel vendor ID. False on non-x86 hosts.
+  static bool isIntelCpu();
+
 #if defined(ATI_ARCH_X86)
   //! Query the processor information about supported features and CPU type.
   static void cpuid(int regs[4], int info);

--- a/rocclr/utils/flags.hpp
+++ b/rocclr/utils/flags.hpp
@@ -255,6 +255,9 @@ release(bool, DEBUG_HIP_KERNARG_COPY_OPT, true,                               \
          "Enable/Disable multiple kern arg copies")                           \
 release(bool, DEBUG_CLR_KERNARG_HDP_FLUSH_WA, false,                          \
         "Toggle kernel arg copy workaround")                                  \
+release(uint, DEBUG_CLR_ORDER_DOORBELL, 2,                                    \
+        "Order shared AQL ring doorbells by reservation "                     \
+        "(0=never, 1=Intel hosts only, 2=every host (default))")              \
 
 namespace amd {
 


### PR DESCRIPTION
## Summary

Backport of the ordered AQL ring publication fix to `release/rocm-rel-6.3.0.1`.

When several VirtualGPUs multiplex onto one physical AQL ring, `hsa_queue_add_write_index_screlease`
advances the GPU-visible write index at *reservation* time. A later producer can therefore expose
its slot while an earlier producer is still writing its packet, and the in-order command processor
parks on that unwritten packet (or consumes torn state).

This splits slot reservation from publication:

- Each pooled hardware queue owns an `AqlOrderedPublishState` with shared reserve/commit indices.
- `VirtualGPU::ReserveAqlSlots()` allocates slots without making them visible to the GPU.
- `VirtualGPU::CommitAqlSlots()` stores the write index and rings the doorbell only once every
  older reservation has been published.

Gated to GenuineIntel hosts and controlled by the new `DEBUG_CLR_ORDER_DOORBELL` flag (default on);
other hosts keep the original HSA multi-producer path. Cooperative and CU-masked queues are not
shared between VirtualGPUs, so they keep the original path as well.

Publication order equals reservation order, so this cannot deadlock: the only blocking operations a
stream performs while holding a reservation (queue slot waits, completion signal waits) wait on
strictly older packets, which are published by definition.

## Notes on this backport

The equivalent change is already on `develop` and `release/rocm-rel-7.2`. Differences here follow
from the older code base:

- No `rocrctx` wrapper layer, so HSA entry points are called directly.
- The state lives in `Device::QueueInfo` (there is no `QueueExtras`), and is looked up under
  `vgpusAccess_`, which is the lock that guards the queue pools on this branch.
- `gpu_queue_` is bound exactly once in `VirtualGPU::create()`, so no `set_gpu_queue()` helper is
  needed to refresh the cached state.
- There is no batch dispatch path on this branch, so the reservation-index accessor used for batch
  pacing on 7.2 is omitted.

## Test plan

- [x] Each modified translation unit compiles clean (`-fsyntax-only`).
- [ ] Runtime validation on a 6.3.0.1 stack (the equivalent 7.2 change passed MultiThreadTest across
      all `GPU_MAX_HW_QUEUES` / `DEBUG_CLR_ORDER_DOORBELL` combinations).