### PR TITLE
Fix __byte_perm sign-replicate selector modes on the device path

### DIFF
--- a/hipamd/include/hip/amd_detail/amd_device_functions.h
+++ b/hipamd/include/hip/amd_detail/amd_device_functions.h
@@ -249,11 +249,22 @@ __device__ static inline unsigned int __byte_perm(unsigned int x, unsigned int y
   cHoldKey.ui = s;
   cHoldVal.ui[0] = x;
   cHoldVal.ui[1] = y;
-  unsigned int result;
-  result = cHoldVal.c[cHoldKey.c[0] & 0x07];
-  result += (cHoldVal.c[(cHoldKey.c[0] & 0x70) >> 4] << 8);
-  result += (cHoldVal.c[cHoldKey.c[1] & 0x07] << 16);
-  result += (cHoldVal.c[(cHoldKey.c[1] & 0x70) >> 4] << 24);
+  // Each of the four output bytes is selected by a nibble of `s`: the low 3
+  // bits index one of the eight source bytes {x, y}, and bit 3 requests
+  // "sign replicate" mode -- the selected byte's most-significant bit is
+  // broadcast across all 8 bits (yielding 0x00 or 0xFF). The previous
+  // implementation masked the index with 0x07/0x70 and dropped the replicate
+  // bit, so selectors with a nibble in [0x8, 0xF] silently returned the plain
+  // byte instead of its sign broadcast. Ref: CUDA __byte_perm / PTX prmt.b32.
+  unsigned int result = 0;
+  for (int i = 0; i < 4; ++i) {
+    unsigned int nib = (s >> (4 * i)) & 0xF;
+    unsigned char b = cHoldVal.c[nib & 0x7];
+    if (nib & 0x8) {
+      b = (b & 0x80) ? 0xFF : 0x00;
+    }
+    result |= ((unsigned int) b) << (8 * i);
+  }
   return result;
 }
 


### PR DESCRIPTION
# Fix `__byte_perm` sign-replicate selector modes on the AMD device path

## Problem

The device implementation of `__byte_perm(x, y, s)` in
`hipamd/include/hip/amd_detail/amd_device_functions.h` ignores the
sign-replicate selector mode. In CUDA (and the PTX `prmt.b32` instruction it
mirrors), each output byte is chosen by a 4-bit nibble of the selector `s`:
the low 3 bits index one of the eight source bytes `{x, y}`, and **bit 3
requests "replicate" mode**, in which the most-significant bit of the selected
byte is broadcast across all 8 bits (producing `0x00` or `0xFF`). This is the
standard way to do a branchless per-byte sign extension.

The current implementation masks the index with `0x07`/`0x70` and never looks
at bit 3, so any selector nibble in `[0x8, 0xF]` silently returns the plain
byte instead of its sign broadcast. Selectors in `[0x0, 0x7]` (the common
case) are unaffected and remain correct.

This is silent: code ported from CUDA that relies on replicate mode compiles
and runs, but computes wrong results only for those selector values, which is
painful to track down. It is present on `clr` master (verified at `a223bb1`)
and in shipping ROCm toolchains.

## Semantics target (please confirm)

This PR targets **bit-compatibility with CUDA `__byte_perm` / PTX `prmt.b32`
(default mode)**, since that is the portability contract most code assumes.
If AMD prefers to define its own `__byte_perm` semantics (e.g. document that
HIP only supports plain selection and leave replicate undefined), that is a
reasonable alternative — but it should then be **documented explicitly**,
because the current behavior looks like an implementation bug rather than a
deliberate semantic choice. Flagging this for maintainer direction.

## Evidence

Host reference implementing the CUDA/PTX semantics, compared against the
shipped emulation (`test_byte_perm_host.c`, run on the selector byte layout,
`x=0x33221100`, `y=0x77665544`):

| selector `s` | CUDA/PTX ref | current emulation | note |
|---|---|---|---|
| `0x00003210` | `0x33221100` | `0x33221100` | plain select — OK |
| `0x00001234` | `0x11223344` | `0x11223344` | plain select — OK |
| `0x0000ba98` | `0x00000000` | `0x33221100` | **replicate — WRONG** |

Aggregate over 200,000 random `(x, y, s)`:

- selectors masked to plain mode (`s & 0x77777777`): **0 mismatches**
- unmasked (replicate modes included): **186,995 / 200,000 mismatches**

Every mismatch involves at least one replicate-mode nibble; no plain-mode
selector is affected.

## Fix

Rewrite the byte assembly as a 4-iteration loop over the selector nibbles,
handling the replicate bit. Verified bit-exact against the CUDA/PTX reference
over **2,000,000 random inputs and the exhaustive 16-bit selector space
(0 mismatches)**.

## Test coverage

- `test_byte_perm_host.c` — host reference vs the old and new emulations
  (proves the old bug and the new fix).
- `test_byte_perm_device.hip` — device-side check of the built-in against the
  host reference over the full 16-bit selector space; exits non-zero on any
  mismatch. Ready to adapt into the `ROCm/hip-tests` catch2 layout
  (`catch/unit/deviceLib/`), see checklist.

## Related

- ROCm/ROCm#6025 (comment) documented the HIP-vs-CUDA `__byte_perm` selector
  divergence for the `>= 8` range while debugging RDNA4 kernels.
- ROCm/ROCm discussion #6618 lists this among RDNA4 LLM-inference findings.
